### PR TITLE
First pass at translation for the French Translation README

### DIFF
--- a/translations/fr/README.md
+++ b/translations/fr/README.md
@@ -1,10 +1,10 @@
-# Babel Handbook
+# Mode d'Emploi de Babel
 
-This handbook is divided into two parts:
+Ce mode d'emploi est divisé entre deux pièces:
 
-  * [User Handbook](user-handbook.md) - How to setup/configure Babel and more.
-  * [Plugin Handbook](plugin-handbook.md) - How to create plugins for Babel.
+  * [Mode d'Emploi de l'Utiliseur](user-handbook.md) - Comment installer/configuer Babel et plus.
+  * [Mode d'Emploi du Plugin](plugin-handbook.md) - Comment créer des plugins pour Babel.
 
-> For future updates, follow [@thejameskyle](https://twitter.com/thejameskyle) on Twitter.
+> Pour les versions dans le futur, suivez [@thejameskyle](https://twitter.com/thejameskyle) sur Twitter.
 
-Si vous êtes entrain de lire une traduction de la documentation anglaise, vous allez sûrement trouver des sections qui ne sont pas encore traduites. Si vous voulez contribuer à la traduction, vous pouvez le faire à l'aide du site Crowdin. Veuillez lire le [guide de contribution](/CONTRIBUTING.md) pour plus d'informations. You will find a number of english words that are programming concepts. If these were translated to other languages there would be a lack of consistency and fluency when reading about them. In many cases you will find the literal translation followed by the english term in parenthesis `()`. For example: Abstract Syntax Trees (ASTs).
+Si vous êtes en train de lire une traduction de la documentation anglaise, vous allez sûrement trouver des sections qui ne sont pas encore traduites. Si vous voulez contribuer à la traduction, vous pouvez le faire à l'aide du site Crowdin. Veuillez lire le [guide de contribution](/CONTRIBUTING.md) pour plus d'informations. Vous trouverez plusieurs mots anglais qui sont des concepts de la programmation. Si ceux-là étaient traduits aux autres langues, il y aurait une manque de cohérence en lisant des langues. En tout cas, vous trouverez la traduction mot à mot suivi avec la phrase anglaise en parenthèse `()`. Par exemple, un Arbre syntaxique abstrait (ASTs).


### PR DESCRIPTION
Will try and chip away at the French translation for the handbooks in the future, however this PR translates the initial `README` file that French users will see when clicking on the French translation of `babel-handbook`.