### PR TITLE
Update advice about caching nested visitors

### DIFF
--- a/translations/en/plugin-handbook.md
+++ b/translations/en/plugin-handbook.md
@@ -1775,9 +1775,13 @@ const MyVisitor = {
 };
 ```
 
-However, this creates a new visitor object everytime `FunctionDeclaration()` is
-called above, which Babel then needs to explode and validate every single time.
-This can be costly, so it is better to hoist the visitor up.
+However, this creates a new visitor object every time `FunctionDeclaration()` is
+called. That can be costly, because Babel does some processing each time a new
+visitor object is passed in (such as exploding keys containing multiple types,
+performing validation, and adjusting the object structure). Because Babel stores
+flags on visitor objects indicating that it's already performed that processing,
+it's better to store the visitor in a variable and pass the same object each
+time.
 
 ```js
 const visitorOne = {

--- a/translations/en/plugin-handbook.md
+++ b/translations/en/plugin-handbook.md
@@ -1731,7 +1731,7 @@ It may also be tempting to call `path.traverse` when looking for a particular
 node type.
 
 ```js
-const visitorOne = {
+const nestedVisitor = {
   Identifier(path) {
     // ...
   }
@@ -1739,7 +1739,7 @@ const visitorOne = {
 
 const MyVisitor = {
   FunctionDeclaration(path) {
-    path.get('params').traverse(visitorOne);
+    path.get('params').traverse(nestedVisitor);
   }
 };
 ```
@@ -1784,7 +1784,7 @@ it's better to store the visitor in a variable and pass the same object each
 time.
 
 ```js
-const visitorOne = {
+const nestedVisitor = {
   Identifier(path) {
     // ...
   }
@@ -1792,7 +1792,7 @@ const visitorOne = {
 
 const MyVisitor = {
   FunctionDeclaration(path) {
-    path.traverse(visitorOne);
+    path.traverse(nestedVisitor);
   }
 };
 ```
@@ -1819,7 +1819,7 @@ You can pass it in as state to the `traverse()` method and have access to it on
 `this` in the visitor.
 
 ```js
-const visitorOne = {
+const nestedVisitor = {
   Identifier(path) {
     if (path.node.name === this.exampleState) {
       // ...
@@ -1830,7 +1830,7 @@ const visitorOne = {
 const MyVisitor = {
   FunctionDeclaration(path) {
     var exampleState = path.node.params[0].name;
-    path.traverse(visitorOne, { exampleState });
+    path.traverse(nestedVisitor, { exampleState });
   }
 };
 ```


### PR DESCRIPTION
It's not obvious from the current explanation that Babel adds flags to the visitor to indicate that it's already processed it, so not obvious why the suggested code would be better (other than saving an object allocation). I didn't know before that it does that. That means that it'd be problematic to do something like this, right?

``` js
const nestedVisitor = {
  Identifier(path) {
  }
};

const MyVisitor = {
  FunctionDeclaration(path) {
    path.traverse(nestedVisitor);
    nestedVistor.Identifier = function () {};
    path.traverse(nestedVisitor);
  }
};
```

(This is just a contrived example, but I mean the general case of calling `traverse()` with a visitor, modifying that visitor, and calling `traverse()` again with it.)

Perhaps that should be noted.

I changed `visitorOne => nestedVisitor` as I think it's more descriptive and easier to understand. Is there any particular reason `MyVisitor` has the first char upcased and the other one didn't?
