### PR TITLE
List languages by the displayed name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ A guided handbook on how to use Babel and how to create plugins for Babel.
 - [العربية](/translations/ar/README.md)
 - [Català](/translations/ca/README.md)
 - [Čeština](/translations/cs/README.md)
-- [中文](/translations/zh-Hans/README.md)
-- [繁體中文](/translations/zh-Hant/README.md)
 - [Danske](/translations/da/README.md)
 - [Deutsch](/translations/de/README.md)
 - [ελληνικά](/translations/el/README.md)
@@ -34,7 +32,8 @@ A guided handbook on how to use Babel and how to create plugins for Babel.
 - [Türkçe](/translations/tr/README.md)
 - [Tiếng Việt](/translations/vi/README.md)
 - [Український](/translations/uk/README.md)
-
+- [中文](/translations/zh-Hans/README.md)
+- [繁體中文](/translations/zh-Hant/README.md)
 
 **[Request another translation](https://github.com/thejameskyle/babel-plugin-handbook/issues/new?title=Translation%20Request:%20[Please%20enter%20language%20here]&body=I%20am%20able%20to%20translate%20this%20language%20[yes/no])**
 

--- a/README.md
+++ b/README.md
@@ -9,39 +9,40 @@ A guided handbook on how to use Babel and how to create plugins for Babel.
 - [العربية](/translations/ar/README.md)
 - [Català](/translations/ca/README.md)
 - [Čeština](/translations/cs/README.md)
+- [中文](/translations/zh-Hans/README.md)
+- [繁體中文](/translations/zh-Hant/README.md)
 - [Danske](/translations/da/README.md)
 - [Deutsch](/translations/de/README.md)
 - [ελληνικά](/translations/el/README.md)
 - [Español](/translations/es-ES/README.md)
-- [Suomi](/translations/fi/README.md)
 - [Français](/translations/fr/README.md)
 - [עִברִית](/translations/he/README.md)
-- [Magyar](/translations/hu/README.md)
 - [Italiano](/translations/it/README.md)
 - [日本語](/translations/ja/README.md)
 - [한국어](/translations/ko/README.md)
-- [Norsk](/translations/no/README.md)
+- [Magyar](/translations/hu/README.md)
 - [Nederlands](/translations/nl/README.md)
+- [Norsk](/translations/no/README.md)
 - [Polskie](/translations/pl/README.md)
 - [Português](/translations/pt-PT/README.md)
 - [Português (Brasil)](/translations/pt-BR/README.md)
 - [Română](/translations/ro/README.md)
-- [Pусский](/translations/ru/README.md)
+- [Русский](/translations/ru/README.md)
 - [Српски језик (Ћирилица)](/translations/sr/README.md)
+- [Suomi](/translations/fi/README.md)
 - [Svenska](/translations/sv-SE/README.md)
 - [Türkçe](/translations/tr/README.md)
-- [Український](/translations/uk/README.md)
 - [Tiếng Việt](/translations/vi/README.md)
-- [中文](/translations/zh-Hans/README.md)
-- [繁體中文](/translations/zh-Hant/README.md)
+- [Український](/translations/uk/README.md)
+
 
 **[Request another translation](https://github.com/thejameskyle/babel-plugin-handbook/issues/new?title=Translation%20Request:%20[Please%20enter%20language%20here]&body=I%20am%20able%20to%20translate%20this%20language%20[yes/no])**
 
-If you are reading a non-english translation of this document you will find a
-number of english words that are programming concepts. If these were translated
+If you are reading a non-English translation of this document you will find a
+number of English words that are programming concepts. If these were translated
 to other languages there would be a lack of consistency and fluency when reading
 about them. In many cases you will find the literal translation followed by the
-english term in parenthesis `()`. For example: Abstract Syntax Trees (ASTs).
+English term in parenthesis `()`. For example: Abstract Syntax Trees (ASTs).
 
 Special thanks to [@sebmck](https://github.com/sebmck/),
 [@hzoo](https://github.com/hzoo),


### PR DESCRIPTION
Instead of by the language code in the not-shown link.
For example, "Suomi" (Finnish) is under S instead of F.

Also spell Русский with the Cyrillic Р instead of the Latin P and cap up English.