### PR TITLE
move an inline code example to a new line

### DIFF
--- a/translations/en/user-handbook.md
+++ b/translations/en/user-handbook.md
@@ -162,7 +162,8 @@ $ npm install --save-dev babel-cli
 ```
 
 > **Note:** Since it's generally a bad idea to run Babel globally you may want
-> to uninstall the global copy by running `npm uninstall --global babel-cli`.
+> to uninstall the global copy by running:  
+`npm uninstall --global babel-cli`
 
 After that finishes installing, your `package.json` file should look like this:
 

--- a/translations/en/user-handbook.md
+++ b/translations/en/user-handbook.md
@@ -162,8 +162,10 @@ $ npm install --save-dev babel-cli
 ```
 
 > **Note:** Since it's generally a bad idea to run Babel globally you may want
-> to uninstall the global copy by running:  
-`npm uninstall --global babel-cli`
+> to uninstall the global copy by running:
+```sh
+$ npm uninstall --global babel-cli
+```
 
 After that finishes installing, your `package.json` file should look like this:
 


### PR DESCRIPTION
readability: npm command is split into 2 lines on small screens when inline, making it harder to understand.