### PR TITLE
Mention computer-science term quasiquotes in babel-template section

### DIFF
--- a/translations/en/plugin-handbook.md
+++ b/translations/en/plugin-handbook.md
@@ -1067,7 +1067,8 @@ generate(ast, {
 
 Babel Template is another tiny but incredibly useful module. It allows you to
 write strings of code with placeholders that you can use instead of manually
-building up a massive AST.
+building up a massive AST. In computer science, this capability is called
+quasiquotes.
 
 ```sh
 $ npm install --save babel-template


### PR DESCRIPTION
This term has longstanding use for referring to strings that are interpretted
as sourcecode, via Scheme, Haskell, LISP, Boo, Scala & many others for a long
time now. Mentioning it will help people familiar with this idea find this
very important gem.

Quasi-quotes! Babel-template! Way way better than writing the code declaratively!