### PR TITLE
Updated outdated links to Babylon repo

### DIFF
--- a/translations/en/plugin-handbook.md
+++ b/translations/en/plugin-handbook.md
@@ -841,7 +841,7 @@ Since Babylon is built with a plugin-based architecture, there is also a
 not yet opened this API to external plugins, although may do so in the future.
 
 To see a full list of plugins, see the
-[Babylon README](https://github.com/babel/babel/blob/master/packages/babylon/README.md#plugins).
+[Babylon README](https://github.com/babel/babylon/blob/master/README.md#plugins).
 
 ## <a id="toc-babel-traverse"></a>[`babel-traverse`](https://github.com/babel/babel/tree/master/packages/babel-traverse)
 


### PR DESCRIPTION
Thanks for taking the time to create this guide! I'm reading through it this morning and I really appreciate it. :)

I noticed you had an outdated link to Babylon when it used to be hosted inside of the main Babel repo so I thought I'd update the references.