### PR TITLE
Fix broken link to "Running Babel CLI from within a project"

### DIFF
--- a/translations/en/user-handbook.md
+++ b/translations/en/user-handbook.md
@@ -276,7 +276,7 @@ $ npm install --save-dev babel-cli
 ```
 
 > **Note:** If you are wondering why we are installing this locally, please read
-> the [Running Babel CLI from within a project](#running-babel-cli--from-within-a-project)
+> the [Running Babel CLI from within a project](#toc-running-babel-cli-from-within-a-project)
 > section above.
 
 Then replace wherever you are running `node` with `babel-node`.

--- a/translations/en/user-handbook.md
+++ b/translations/en/user-handbook.md
@@ -348,7 +348,7 @@ babel.transformFromAst(ast, code, options);
 ```
 
 For all of the above methods, `options` refers to
-http://babeljs.io/docs/usage/options/.
+https://babeljs.io/docs/usage/api/#options.
 
 ----
 


### PR DESCRIPTION
I am trying to learn more about Babel and stumbled upon this broken link. This patch fixes the broken link.