### PR TITLE
Remove "Debugging Babel" from Table of Contents

### DIFF
--- a/translations/en/user-handbook.md
+++ b/translations/en/user-handbook.md
@@ -38,7 +38,6 @@ a complete list.
   - [Frameworks](#toc-frameworks)
     - [React](#toc-react)
   - [Text Editors and IDEs](#toc-text-editors-and-ides)
-- [Debugging Babel](#toc-debugging-babel)
 - [Babel Support](#toc-babel-support)
   - [Babel Forum](#toc-babel-forum)
   - [Babel Chat](#toc-babel-chat)


### PR DESCRIPTION
In this patch, the "Debugging Babel" section is removed from the Table of Contents since it does not exist. 