### PR TITLE
Make example code work for babel-generator

### DIFF
--- a/translations/en/plugin-handbook.md
+++ b/translations/en/plugin-handbook.md
@@ -1079,7 +1079,7 @@ const code = `function square(n) {
 
 const ast = babylon.parse(code);
 
-generate(ast, null, code);
+generate(ast, {}, code);
 // {
 //   code: "...",
 //   map: "..."


### PR DESCRIPTION
Make it work with babel-generator from master and fix this error message:
"Cannot read property 'auxiliaryCommentBefore' of null"