### PR TITLE
Added ObjectMethod and ClassMethod to Function alias

### DIFF
--- a/translations/en/plugin-handbook.md
+++ b/translations/en/plugin-handbook.md
@@ -497,7 +497,7 @@ You can also use aliases as visitor nodes (as defined in [babel-types](https://g
 
 For example,
 
-`Function` is an alias for `FunctionDeclaration`, `FunctionExpression`, `ArrowFunctionExpression`
+`Function` is an alias for `FunctionDeclaration`, `FunctionExpression`, `ArrowFunctionExpression`, `ObjectMethod` and `ClassMethod`.
 
 ```js
 const MyVisitor = {


### PR DESCRIPTION
I looked at the docs of `babel-types`, tried it on astexplorer and also checked the exported alias list of the package. It seems like the example for aliases ( `Function` ) currently is incomplete.