### PR TITLE
mention use of this.opts in pre/post functions

### DIFF
--- a/translations/en/plugin-handbook.md
+++ b/translations/en/plugin-handbook.md
@@ -1762,6 +1762,9 @@ plugins.
 Plugins can have functions that are run before or after plugins.
 They can be used for setup or cleanup/analysis purposes.
 
+Within these functions, you can access plugin options (as per the previous
+section) via `this.opts` (and not through `state`, like in visitor functions).
+
 ```js
 export default function({ types: t }) {
   return {
@@ -1774,7 +1777,8 @@ export default function({ types: t }) {
       }
     },
     post(state) {
-      console.log(this.cache);
+      if (this.opts.showCache)
+        console.log(this.cache);
     }
   };
 }


### PR DESCRIPTION
since it's via `state.opts` in visitor functions.

Hope the small change to the example is a good fit.